### PR TITLE
Document `NoScopesForNamespaces` and `InvalidExtraScopes` errors

### DIFF
--- a/openapi/components/responses/error400.yaml
+++ b/openapi/components/responses/error400.yaml
@@ -9,3 +9,5 @@ content:
         - $ref: ../schemas/UniqueConstraint.yaml
         - $ref: ../schemas/NoItemRevision.yaml
         - $ref: ../schemas/InvalidOperandValue.yaml
+        - $ref: ../schemas/NoScopesForNamespaces.yaml
+        - $ref: ../schemas/InvalidExtraScopes.yaml

--- a/openapi/components/schemas/InvalidExtraScopes.yaml
+++ b/openapi/components/schemas/InvalidExtraScopes.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  code:
+    type: string
+    description: InvalidExtraScopes
+  type:
+    type: string
+    description: system
+  template:
+    type: string
+    description: |
+      Request contains extra scopes that are not defined in contract. Extra scopes: {extra_scopes}.
+  message:
+    description: |
+      Message within the error object contains a more detailed description of the server errors.
+      These should include more detailed overview of the internal, business logic or request processing errors that have occurred.
+    type: string
+  additionalProperties: true

--- a/openapi/components/schemas/NoScopesForNamespaces.yaml
+++ b/openapi/components/schemas/NoScopesForNamespaces.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  code:
+    type: string
+    description: NoScopesForNamespaces
+  type:
+    type: string
+    description: system
+  template:
+    type: string
+    description: |
+      Request contains no scopes from available namespaces: {namespaces}.
+  message:
+    description: |
+      Message within the error object contains a more detailed description of the server errors.
+      These should include more detailed overview of the internal, business logic or request processing errors that have occurred.
+    type: string
+  additionalProperties: true

--- a/v1.0/openapi/components/responses/error400.yaml
+++ b/v1.0/openapi/components/responses/error400.yaml
@@ -9,3 +9,5 @@ content:
         - $ref: ../schemas/UniqueConstraint.yaml
         - $ref: ../schemas/NoItemRevision.yaml
         - $ref: ../schemas/InvalidOperandValue.yaml
+        - $ref: ../schemas/NoScopesForNamespaces.yaml
+        - $ref: ../schemas/InvalidExtraScopes.yaml

--- a/v1.0/openapi/components/schemas/InvalidExtraScopes.yaml
+++ b/v1.0/openapi/components/schemas/InvalidExtraScopes.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  code:
+    type: string
+    description: InvalidExtraScopes
+  type:
+    type: string
+    description: system
+  template:
+    type: string
+    description: |
+      Request contains extra scopes that are not defined in contract. Extra scopes: {extra_scopes}.
+  message:
+    description: |
+      Message within the error object contains a more detailed description of the server errors.
+      These should include more detailed overview of the internal, business logic or request processing errors that have occurred.
+    type: string
+  additionalProperties: true

--- a/v1.0/openapi/components/schemas/NoScopesForNamespaces.yaml
+++ b/v1.0/openapi/components/schemas/NoScopesForNamespaces.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  code:
+    type: string
+    description: NoScopesForNamespaces
+  type:
+    type: string
+    description: system
+  template:
+    type: string
+    description: |
+      Request contains no scopes from available namespaces: {namespaces}.
+  message:
+    description: |
+      Message within the error object contains a more detailed description of the server errors.
+      These should include more detailed overview of the internal, business logic or request processing errors that have occurred.
+    type: string
+  additionalProperties: true

--- a/v1.1/openapi/components/responses/error400.yaml
+++ b/v1.1/openapi/components/responses/error400.yaml
@@ -9,3 +9,5 @@ content:
         - $ref: ../schemas/UniqueConstraint.yaml
         - $ref: ../schemas/NoItemRevision.yaml
         - $ref: ../schemas/InvalidOperandValue.yaml
+        - $ref: ../schemas/NoScopesForNamespaces.yaml
+        - $ref: ../schemas/InvalidExtraScopes.yaml

--- a/v1.1/openapi/components/schemas/InvalidExtraScopes.yaml
+++ b/v1.1/openapi/components/schemas/InvalidExtraScopes.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  code:
+    type: string
+    description: InvalidExtraScopes
+  type:
+    type: string
+    description: system
+  template:
+    type: string
+    description: |
+      Request contains extra scopes that are not defined in contract. Extra scopes: {extra_scopes}.
+  message:
+    description: |
+      Message within the error object contains a more detailed description of the server errors.
+      These should include more detailed overview of the internal, business logic or request processing errors that have occurred.
+    type: string
+  additionalProperties: true

--- a/v1.1/openapi/components/schemas/NoScopesForNamespaces.yaml
+++ b/v1.1/openapi/components/schemas/NoScopesForNamespaces.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  code:
+    type: string
+    description: NoScopesForNamespaces
+  type:
+    type: string
+    description: system
+  template:
+    type: string
+    description: |
+      Request contains no scopes from available namespaces: {namespaces}.
+  message:
+    description: |
+      Message within the error object contains a more detailed description of the server errors.
+      These should include more detailed overview of the internal, business logic or request processing errors that have occurred.
+    type: string
+  additionalProperties: true


### PR DESCRIPTION
**Summary:**
Documents newly added Spinta errors `NoScopesForNamespaces` and `InvalidExtraScopes` related to Spinta scope checks from smart contracts.

It's my first time working with Redocly, I have no idea if I added errors correctly.

**Ticket:**
https://github.com/atviriduomenys/spinta/issues/1598

