### PR TITLE
[2273] Remove outer `_type` inconsistency

### DIFF
--- a/openapi/components/schemas/objects.yaml
+++ b/openapi/components/schemas/objects.yaml
@@ -1,9 +1,5 @@
 type: object
 properties:
-  _type:
-    type: string
-    examples:
-      - datasets/gov/dc/geo/Continent
   _data:
     type: array
     items:

--- a/v1.0/openapi/components/schemas/objects.yaml
+++ b/v1.0/openapi/components/schemas/objects.yaml
@@ -1,9 +1,5 @@
 type: object
 properties:
-  _type:
-    type: string
-    examples:
-      - datasets/gov/dc/geo/Continent
   _data:
     type: array
     items:

--- a/v1.1/openapi/components/schemas/objects.yaml
+++ b/v1.1/openapi/components/schemas/objects.yaml
@@ -1,9 +1,5 @@
 type: object
 properties:
-  _type:
-    type: string
-    examples:
-      - datasets/gov/dc/geo/Continent
   _data:
     type: array
     items:


### PR DESCRIPTION
Update documentation by removing the `_type` attribute inside LIST return, discussed that it is not needed there.